### PR TITLE
define create input for metric resource

### DIFF
--- a/pbf/metric/create.proto
+++ b/pbf/metric/create.proto
@@ -3,10 +3,34 @@ syntax = "proto3";
 package metric;
 option go_package = ".;metric";
 
+// CreateI is the input to create a metric. That is persisting datapoints
+// associated with an update. Below is an example JSON representation showing an
+// emitted datapoint for the dimensions x and y, where x represents a Unix
+// Timestamp and y represents a numeric value given by the user at that time.
+//
+//     {
+//         "datapoint": [
+//             1604959525,
+//             85
+//         ],
+//         "metric_id": "met-d289g",
+//         "timestamp": "1604959525",
+//         "update_id": "upd-j3o45"
+//     }
+//
 message CreateI {
-  string name = 1;
+  // datapoint is a list of datapoints provided by convention. Providing [x, y]
+  // may be interpreted as datapoints for x and y dimensions on a graph.
+  repeated int64 datapoint = 1;
+  // metric_id is the identifier used to associate the given datapoints with the
+  // specified metric.
+  string metric_id = 2;
+  // timestamp is the time at which the datapoints got emitted. With conventions
+  // of the x axis to be time, the first datapoint and timestamp must be equal.
+  string timestamp = 3;
+  // update_id is the identifier used to associate the created metric with the
+  // specified update.
+  string update_id = 4;
 }
 
-message CreateO {
-  string message = 1;
-}
+message CreateO { }

--- a/pbf/metric/create.proto
+++ b/pbf/metric/create.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package metric;
 option go_package = ".;metric";
 
-// CreateI is the input to create a metric. That is persisting datapoints
+// CreateI is the input to create metrics. That is persisting datapoints
 // associated with an update. Below is an example JSON representation showing an
 // emitted datapoint for the dimensions x and y, where x represents a Unix
 // Timestamp and y represents a numeric value given by the user at that time.


### PR DESCRIPTION
This is some first draft of which I think it makes mostly sense. You see the input required in order to create a metric. The output is empty for now since I would approach no error as success. If there are more requirements or other information be returned by the apiserver at some point we can gladly extend. 