### PR TITLE
add texupd resource

### DIFF
--- a/pbf/texupd/api.proto
+++ b/pbf/texupd/api.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package texupd;
+option go_package = ".;texupd";
+
+import "pbf/texupd/create.proto";
+import "pbf/texupd/delete.proto";
+import "pbf/texupd/search.proto";
+import "pbf/texupd/update.proto";
+
+service API {
+  rpc Create(CreateI) returns (CreateO) {}
+  rpc Delete(DeleteI) returns (DeleteO) {}
+  rpc Search(SearchI) returns (SearchO) {}
+  rpc Update(UpdateI) returns (UpdateO) {}
+}

--- a/pbf/texupd/create.proto
+++ b/pbf/texupd/create.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package texupd;
+option go_package = ".;texupd";
+
+// CreateI is the input for creating text updates. That is persisting text a
+// user adds to a timeline. Below is an example JSON representation showing an
+// emitted text update.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "timeline.venturemark.co/id": "1606396471",
+//                 "user.venturemark.co/id": "usr-al9qy"
+//             }
+//             "property": {
+//                 "text": "Lorem ipsum ..."
+//             }
+//         }
+//     }
+//
+message CreateI {
+  CreateI_API api = 1;
+  CreateI_Obj obj = 2;
+}
+
+message CreateI_API {}
+
+message CreateI_Obj {
+  map<string, string> metadata = 1;
+  CreateI_Obj_Property property = 2;
+}
+
+message CreateI_Obj_Property {
+  string text = 1;
+}
+
+// CreateO is the output for creating text updates. Only the exact unix
+// timestamp of creation is returned with the object metadata when successfully
+// creating a text update.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "update.venturemark.co/id": "1606400781"
+//             }
+//         }
+//     }
+//
+message CreateO {
+  CreateO_API api = 1;
+  CreateO_Obj obj = 2;
+}
+
+message CreateO_API {}
+
+message CreateO_Obj {
+  map<string, string> metadata = 1;
+}

--- a/pbf/texupd/delete.proto
+++ b/pbf/texupd/delete.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package texupd;
+option go_package = ".;texupd";
+
+// Text updates are not supported to be deleted at this point in time. The
+// apischema and its corresponding implementation might change that in the
+// future.
+
+message DeleteI {}
+message DeleteO {}

--- a/pbf/texupd/search.proto
+++ b/pbf/texupd/search.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package texupd;
+option go_package = ".;texupd";
+
+// Text updates are not meant to be searched on their own. Searching a text
+// update means to search an update separately. See pbf/update for more
+// information.
+
+message SearchI {}
+message SearchO {}

--- a/pbf/texupd/update.proto
+++ b/pbf/texupd/update.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package texupd;
+option go_package = ".;texupd";
+
+// UpdateI is the input for updating text updates. For more information about
+// text updates as a separate resource see create.proto.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "timeline.venturemark.co/id": "1606396471",
+//                 "update.venturemark.co/id": "1606400781",
+//                 "user.venturemark.co/id": "usr-al9qy"
+//             }
+//             "property": {
+//                 "text": "Lorem ipsum ..."
+//             }
+//         }
+//     }
+//
+message UpdateI {
+  UpdateI_API api = 1;
+  UpdateI_Obj obj = 2;
+}
+
+message UpdateI_API {}
+
+message UpdateI_Obj {
+  map<string, string> metadata = 1;
+  UpdateI_Obj_Property property = 2;
+}
+
+message UpdateI_Obj_Property {
+  string text = 1;
+}
+
+// UpdateO is the output for updating text updates. The response will contain
+// object metadata to indicate the text update got in fact updated. The example
+// below indicates that the update resource got updated. That is, the text
+// changed.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "update.venturemark.co/status": "updated"
+//             }
+//     }
+//
+message UpdateO {
+  UpdateO_API api = 1;
+  UpdateO_Obj obj = 2;
+}
+
+message UpdateO_API {}
+
+message UpdateO_Obj {
+  map<string, string> metadata = 1;
+}


### PR DESCRIPTION
For our current iteration we take a step back and neglect metric updates. For now we only care about text updates. So this PR adds a dedicated resource for our new use case to have a clear separation of concerns in the backend. Note that merging this pull request will automatically re-generate language specific code for Golang and Typescript. These projects are used in our `apiserver` and `webclient` projects respectively. 

- https://github.com/venturemark/apigengo
- https://github.com/venturemark/apigents