### PR TITLE
add audience resource

### DIFF
--- a/pbf/audience/api.proto
+++ b/pbf/audience/api.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package audience;
+option go_package = ".;audience";
+
+import "pbf/audience/create.proto";
+import "pbf/audience/delete.proto";
+import "pbf/audience/search.proto";
+import "pbf/audience/update.proto";
+
+service API {
+  rpc Create(CreateI) returns (CreateO) {}
+  rpc Delete(DeleteI) returns (DeleteO) {}
+  rpc Search(SearchI) returns (SearchO) {}
+  rpc Update(UpdateI) returns (UpdateO) {}
+}

--- a/pbf/audience/create.proto
+++ b/pbf/audience/create.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package audience;
+option go_package = ".;audience";
+
+// CreateI is the input for creating audiences.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "organization.venturemark.co/id": "org-pl142"
+//                 "user.venturemark.co/id": "usr-al9qy"
+//             }
+//             "property": {
+//                 "name": "Employees",
+//                 "user": [
+//                     "usr-pl1d6",
+//                     "usr-403x9",
+//                 ]
+//             }
+//         }
+//     }
+//
+message CreateI {
+  CreateI_API api = 1;
+  CreateI_Obj obj = 2;
+}
+
+message CreateI_API {}
+
+message CreateI_Obj {
+  map<string, string> metadata = 1;
+  CreateI_Obj_Property property = 2;
+}
+
+message CreateI_Obj_Property {
+  string name = 1;
+  repeated string user = 2;
+}
+
+// CreateO is the output for creating audiences. Only the exact unix timestamp
+// of creation is returned with the object metadata when successfully creating
+// an audience.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "audience.venturemark.co/id": "1606396471"
+//             }
+//         }
+//     }
+//
+message CreateO {
+  CreateO_API api = 1;
+  CreateO_Obj obj = 2;
+}
+
+message CreateO_API {}
+
+message CreateO_Obj {
+  map<string, string> metadata = 1;
+}

--- a/pbf/audience/delete.proto
+++ b/pbf/audience/delete.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package audience;
+option go_package = ".;audience";
+
+message DeleteI {}
+message DeleteO {}

--- a/pbf/audience/search.proto
+++ b/pbf/audience/search.proto
@@ -1,0 +1,97 @@
+syntax = "proto3";
+
+package audience;
+option go_package = ".;audience";
+
+// SearchI is the input for searching audiences.
+//
+//     {
+//         "api": {
+//             "chunking": {
+//                 "perpage": "100",
+//                 "pointer": "300"
+//             }
+//         },
+//         "obj": [
+//             {
+//                 "metadata": {
+//                     "organization.venturemark.co/id": "org-pl142"
+//                     "user.venturemark.co/id": "usr-al9qy"
+//                 }
+//             }
+//         ]
+//     }
+//
+message SearchI {
+  SearchI_API api = 1;
+  repeated SearchI_Obj obj = 2;
+}
+
+message SearchI_API {
+  SearchI_API_Chunking chunking = 1;
+  repeated string operator = 2;
+}
+
+message SearchI_API_Chunking {
+  string pointer = 1;
+  string perpage = 2;
+}
+
+message SearchI_Obj {
+  map<string, string> metadata = 1;
+  SearchI_Obj_Property property = 2;
+}
+
+message SearchI_Obj_Property {}
+
+// SearchO is the output for searching audiences.
+//
+//     {
+//         "api": {
+//             "chunking": {
+//                 "perpage": "100",
+//                 "pointer": "300"
+//             }
+//         },
+//         "obj": [
+//             {
+//                 "metadata": {
+//                     "timeline.venturemark.co/id": "1606396471",
+//                     "user.venturemark.co/id": "usr-al9qy"
+//                 },
+//                 "property": {
+//                     "name": "monthly recurring revenue",
+//                     "user": [
+//                         "usr-al9qy",
+//                         "usr-pl1d6",
+//                         "usr-403x9",
+//                     ]
+//                 }
+//             },
+//             ...
+//         ]
+//     }
+//
+message SearchO {
+  SearchO_API api = 1;
+  repeated SearchO_Obj obj = 2;
+}
+
+message SearchO_API {
+  SearchO_API_Chunking chunking = 1;
+}
+
+message SearchO_API_Chunking {
+  string pointer = 1;
+  string perpage = 2;
+}
+
+message SearchO_Obj {
+  map<string, string> metadata = 1;
+  SearchO_Obj_Property property = 2;
+}
+
+message SearchO_Obj_Property {
+  string name = 1;
+  repeated string user = 2;
+}

--- a/pbf/audience/update.proto
+++ b/pbf/audience/update.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package audience;
+option go_package = ".;audience";
+
+message UpdateI {}
+message UpdateO {}


### PR DESCRIPTION
Based on the current idea we want founders and members of an organization enable to write updates for audiences. Therefore we need an audience resource that can be worked with accordingly. For the `apiserver`  this means to bind timelines to audiences instead of users.  