### PR TITLE
add schema to delete audiences

### DIFF
--- a/pbf/audience/delete.proto
+++ b/pbf/audience/delete.proto
@@ -3,5 +3,46 @@ syntax = "proto3";
 package audience;
 option go_package = ".;audience";
 
-message DeleteI {}
-message DeleteO {}
+// DeleteI is the input for deleting audiences.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "audience.venturemark.co/id": "<id>",
+//                 "organization.venturemark.co/id": "<id>",
+//                 "user.venturemark.co/id": "<id>"
+//             }
+//         }
+//     }
+//
+message DeleteI {
+  DeleteI_API api = 1;
+  DeleteI_Obj obj = 2;
+}
+
+message DeleteI_API {}
+
+message DeleteI_Obj {
+  map<string, string> metadata = 1;
+}
+
+// DeleteO is the output for deleting audiences.
+//
+//     {
+//         "obj": {
+//             "metadata": {
+//                 "audience.venturemark.co/status": "deleted",
+//             }
+//         }
+//     }
+//
+message DeleteO {
+  DeleteO_API api = 1;
+  DeleteO_Obj obj = 2;
+}
+
+message DeleteO_API {}
+
+message DeleteO_Obj {
+  map<string, string> metadata = 1;
+}


### PR DESCRIPTION
For writing conformance tests I also want to ensure audiences can be deleted. The interface for that is super simple. It only takes the audience specific metadata and returns the `deleted` status in case of success. 