### PR TITLE
add metadata for invite update

### DIFF
--- a/pbf/invite/update.proto
+++ b/pbf/invite/update.proto
@@ -13,6 +13,8 @@ option go_package = "./;invite";
 //                 "metadata": {
 //                     "invite.venturemark.co/code": "<code>",
 //                     "invite.venturemark.co/id": "<id>",
+//                     "resource.venturemark.co/kind": "venture",
+//                     "role.venturemark.co/kind": "member",
 //                     "venture.venturemark.co/id": "<id>"
 //                 },
 //                 "jsnpatch": [


### PR DESCRIPTION
@marcusellison here an example for updating invites. Instead of "venture/member" you could set "timeline/reader" for instance. 